### PR TITLE
Finished TODO: Stark\Core\System::getLocalIp()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 .tmproj
 nbproject
 Thumbs.db
+.idea

--- a/src/Stark/Core/System.php
+++ b/src/Stark/Core/System.php
@@ -2,6 +2,9 @@
 namespace Stark\Core;
 
 class System {
+    const OS_TYPE_MAC_OS = 'Darwin';
+    const OS_TYPE_LINUX  = 'Linux';
+
     public static function runInBackground() {
         $pid = pcntl_fork();
         if ($pid == -1) die("Unable to fork\r\n");
@@ -41,8 +44,29 @@ class System {
         //TODO
     }
 
-    public static function getLocalIp() {
-        //TODO
+    public static function getLocalIp($device = '') {
+        $osType = ucfirst(strtolower(php_uname('s')));
+
+        $awkCommand = 'awk \'/inet / {ipstr = $0;gsub("addr:", "", ipstr);split(ipstr, ip, " ");print ip[2]}\'';
+
+        if (!$device)
+        {
+            // Linux and other OS use eth0 as default device
+            $device = 'eth0';
+
+            if ($osType == self::OS_TYPE_MAC_OS)
+            {
+                $device = 'en0';
+            }
+        }
+
+        $ip = trim(shell_exec("ifconfig {$device} | " . $awkCommand));
+
+        if ($ip)
+        {
+            return $ip;
+        }
+
         return '0.0.0.0';
     }
 }

--- a/src/Stark/Core/System.php
+++ b/src/Stark/Core/System.php
@@ -47,14 +47,11 @@ class System {
     public static function getLocalIp($device = '') {
         $osType = ucfirst(strtolower(php_uname('s')));
 
-
-        if (!$device)
-        {
+        if (!$device) {
             // Linux and other OS use eth0 as default device
             $device = 'eth0';
 
-            if ($osType == self::OS_TYPE_MAC_OS)
-            {
+            if ($osType == self::OS_TYPE_MAC_OS) {
                 $device = 'en0';
             }
         }
@@ -63,8 +60,7 @@ class System {
         $awkCommand = 'awk \'/inet / {ipstr = $0;gsub("addr:", "", ipstr);split(ipstr, ip, " ");print ip[2]}\'';
         $ip = trim(shell_exec("{$checkDeviceCommand} && (ifconfig {$device} | {$awkCommand})"));
 
-        if ($ip && $ip != 'false')
-        {
+        if ($ip && $ip != 'false') {
             return $ip;
         }
 

--- a/src/Stark/Core/System.php
+++ b/src/Stark/Core/System.php
@@ -59,7 +59,7 @@ class System {
             }
         }
 
-        $checkDeviceCommand = "(ifconfig {$device} 1> /dev/null 2>&1 || (echo false && exit 1))";
+        $checkDeviceCommand = "(ifconfig {$device} >> /dev/null 2>&1 || (echo false && exit 1))";
         $awkCommand = 'awk \'/inet / {ipstr = $0;gsub("addr:", "", ipstr);split(ipstr, ip, " ");print ip[2]}\'';
         $ip = trim(shell_exec("{$checkDeviceCommand} && (ifconfig {$device} | {$awkCommand})"));
 
@@ -71,5 +71,3 @@ class System {
         return '0.0.0.0';
     }
 }
-
-echo System::getLocalIp();

--- a/src/Stark/Core/System.php
+++ b/src/Stark/Core/System.php
@@ -47,7 +47,6 @@ class System {
     public static function getLocalIp($device = '') {
         $osType = ucfirst(strtolower(php_uname('s')));
 
-        $awkCommand = 'awk \'/inet / {ipstr = $0;gsub("addr:", "", ipstr);split(ipstr, ip, " ");print ip[2]}\'';
 
         if (!$device)
         {
@@ -60,9 +59,11 @@ class System {
             }
         }
 
-        $ip = trim(shell_exec("ifconfig {$device} | " . $awkCommand));
+        $checkDeviceCommand = "(ifconfig {$device} 1> /dev/null 2>&1 || (echo false && exit 1))";
+        $awkCommand = 'awk \'/inet / {ipstr = $0;gsub("addr:", "", ipstr);split(ipstr, ip, " ");print ip[2]}\'';
+        $ip = trim(shell_exec("{$checkDeviceCommand} && (ifconfig {$device} | {$awkCommand})"));
 
-        if ($ip)
+        if ($ip && $ip != 'false')
         {
             return $ip;
         }
@@ -70,3 +71,5 @@ class System {
         return '0.0.0.0';
     }
 }
+
+echo System::getLocalIp();


### PR DESCRIPTION
Used shell command:

``` sh
(ifconfig eth0 >> /dev/null 2>&1 || (echo false && exit 1)) && (ifconfig eth0 | awk '/inet / {ipstr = $0;gsub("addr:", "", ipstr);split(ipstr, ip, " ");print ip[2]}')
```

`eth0` should be replaced as `en0` on `Mac OS X`
